### PR TITLE
Update package.json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "keywords": [
     "chai",
+    "chai-plugin",
+    "browser",
     "generator",
     "es6",
     "test",


### PR DESCRIPTION
These keywords allow the new chai-docs site to automatically find and register
chai-generator as a plugin for the plugins page.

You can read https://github.com/chaijs/chai-docs/issues/34 but the gist of it is:
- You don't need to pull request chai docs any more to add plugins
- You need to add the `chai-plugin` keyword to your npm keywords for chai-docs to be able to find the plugin
- `browser` can be added in the keywords, if your plugin supports browsers.
